### PR TITLE
Add React evaluation prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# grow
-Grow for restaurants
+# Grow Evaluador
+
+Esta aplicaci\u00f3n en React permite evaluar emprendimientos seg\u00fan 10 factores propuestos por Y Combinator. Utiliza Material UI y Tailwind CSS por CDN y est\u00e1 dise\u00f1ada con tonos azules, verdes y amarillos.
+
+## Uso
+
+Instala las dependencias y ejecuta un servidor est\u00e1tico:
+
+```bash
+npm install
+npm start
+```
+
+Luego abre `http://localhost:3000`.
+
+Para almacenar las respuestas en Google Sheets se deben configurar `SHEET_ID` y `API_KEY` en `src/App.jsx`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "grow-evaluador",
+  "version": "1.0.0",
+  "description": "Sistema para evaluar emprendimientos",
+  "scripts": {
+    "start": "serve public",
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@mui/material": "^5.15.0"
+  },
+  "devDependencies": {
+    "serve": "^14.2.0"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="description" content="Evaluación de emprendimientos" />
+  <title>Evaluar Emprendimiento</title>
+  <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-blue-50">
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+</html>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+import {
+  Container,
+  TextField,
+  Slider,
+  Button,
+  Typography,
+} from 'https://cdn.skypack.dev/@mui/material';
+
+const factors = [
+  'Problema real y doloroso',
+  'Mercado grande y en crecimiento',
+  'Soluci\u00f3n diferenciada y simple',
+  'Ventaja competitiva',
+  'Modelo de negocio s\u00f3lido',
+  'Tracci\u00f3n o validaci\u00f3n temprana',
+  'Equipo fundador fuerte y con insight \u00fanico',
+  'Go-to-market estrat\u00e9gico',
+  'Escalabilidad del producto',
+  'Velocidad de ejecuci\u00f3n / foco',
+];
+
+function Question({ label, value, onChange }) {
+  return (
+    <div className="my-4">
+      <Typography variant="subtitle1" className="text-gray-700">{label}</Typography>
+      <Slider
+        value={value}
+        onChange={(_, val) => onChange(val)}
+        min={1}
+        max={100}
+        step={1}
+        valueLabelDisplay="auto"
+        aria-labelledby={label}
+      />
+    </div>
+  );
+}
+
+export default function App() {
+  const [answers, setAnswers] = useState(() =>
+    factors.map(() => [50, 50, 50])
+  );
+
+  const handleChange = (factorIndex, questionIndex, newVal) => {
+    setAnswers((prev) => {
+      const copy = [...prev];
+      copy[factorIndex][questionIndex] = newVal;
+      return copy;
+    });
+  };
+
+  const handleSubmit = async () => {
+    const data = factors.map((factor, idx) => ({
+      factor,
+      q1: answers[idx][0],
+      q2: answers[idx][1],
+      q3: answers[idx][2],
+    }));
+
+    try {
+      // TODO: replace SHEET_ID and API_KEY with real values
+      const sheetId = 'SHEET_ID';
+      const apiKey = 'API_KEY';
+      await fetch(
+        `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/Respuestas:append?valueInputOption=USER_ENTERED&key=${apiKey}`,
+        {
+          method: 'POST',
+          body: JSON.stringify({ values: data.map((d) => Object.values(d)) }),
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+      alert('Respuestas enviadas');
+    } catch (e) {
+      console.error(e);
+      alert('Error al enviar datos');
+    }
+  };
+
+  return (
+    <Container className="max-w-3xl mx-auto p-4">
+      <Typography variant="h4" gutterBottom className="text-blue-800">
+        Evaluaci\u00f3n de Emprendimiento
+      </Typography>
+      {factors.map((factor, idx) => (
+        <div key={factor} className="my-6 p-4 bg-white rounded shadow-sm">
+          <Typography variant="h6" className="text-green-700 mb-2">
+            {`#${idx + 1} ${factor}`}
+          </Typography>
+          {[1, 2, 3].map((q) => (
+            <Question
+              key={q}
+              label={`Pregunta ${q}`}
+              value={answers[idx][q - 1]}
+              onChange={(val) => handleChange(idx, q - 1, val)}
+            />
+          ))}
+        </div>
+      ))}
+      <Button
+        variant="contained"
+        className="bg-yellow-500 hover:bg-yellow-600 mt-4"
+        onClick={handleSubmit}
+      >
+        Enviar
+      </Button>
+    </Container>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const rootElement = document.getElementById('root');
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- create React-based evaluation app skeleton
- configure Material UI & Tailwind via CDN
- add placeholder Google Sheets integration
- document install instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68713a1662fc832e9c012d1db263895c